### PR TITLE
fix: try add plugin(functions) when SseMap and StdioMap cache hits

### DIFF
--- a/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
@@ -136,6 +136,15 @@ public static class KernelExtensions
 
         if (StdioMap.TryGetValue(key, out var stdioKernelPlugin))
         {
+            try
+            {
+                plugins.AddFromFunctions(key, stdioKernelPlugin.ToArray());
+            }
+            catch
+            {
+                // one or more functions have been added to plugins.
+            }
+
             return stdioKernelPlugin;
         }
 
@@ -238,6 +247,15 @@ public static class KernelExtensions
 
         if (SseMap.TryGetValue(key, out var sseKernelPlugin))
         {
+            try
+            {
+                plugins.AddFromFunctions(key, sseKernelPlugin.ToArray());
+            }
+            catch
+            {
+                // one or more functions have been added to plugins.
+            }
+
             return sseKernelPlugin;
         }
 


### PR DESCRIPTION
When SseMap and StdioMap cache hits, the code will not run `plugins.AddFromFunctions`, so if the Kernel object(from Semantic Kernel) is a new instance(with empty `Kernel.Plugins`) , MCP service(with same key) can just hit once in the program lifecycle.