### PR TITLE
Add abillity to provide HttpClient to MCP Tool calls.

### DIFF
--- a/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
@@ -169,7 +169,7 @@ public static class KernelExtensions
 	/// <param name="endpoint">The endpoint (location).</param>
 	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
@@ -177,7 +177,7 @@ public static class KernelExtensions
         string endpoint,
         ILoggerFactory? loggerFactory = null,
         CancellationToken cancellationToken = default,
-		HttpClient? httpClient = default)
+        HttpClient? httpClient = default)
     {
         return AddMcpFunctionsFromSseServerAsync(plugins, serverName, new Uri(endpoint), loggerFactory, cancellationToken, httpClient);
     }
@@ -190,7 +190,7 @@ public static class KernelExtensions
 	/// <param name="endpoint">The endpoint (location).</param>
 	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
@@ -198,7 +198,7 @@ public static class KernelExtensions
         Uri endpoint,
         ILoggerFactory? loggerFactory = null,
         CancellationToken cancellationToken = default,
-		HttpClient? httpClient = default)
+        HttpClient? httpClient = null)
     {
         Guard.NotNull(plugins);
         Guard.NotNullOrWhiteSpace(serverName);
@@ -218,13 +218,13 @@ public static class KernelExtensions
 	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
 	/// <param name="optionsCallback">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/> callback.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
         Action<ModelContextProtocolSemanticKernelSseOptions> optionsCallback,
-        CancellationToken cancellationToken = default,
-		HttpClient? httpClient = default)
+        CancellationToken cancellationToken = default, 
+        HttpClient? httpClient = null)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(optionsCallback);
@@ -233,7 +233,7 @@ public static class KernelExtensions
         optionsCallback(options);
 
         return AddMcpFunctionsFromSseServerAsync(plugins, options, cancellationToken, httpClient);
-    }
+	}
 
 	/// <summary>
 	/// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
@@ -241,9 +241,9 @@ public static class KernelExtensions
 	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
 	/// <param name="options">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = default)
+	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = null)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(options);

--- a/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
@@ -169,7 +169,7 @@ public static class KernelExtensions
 	/// <param name="endpoint">The endpoint (location).</param>
 	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
+	/// <param name="httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
@@ -190,7 +190,7 @@ public static class KernelExtensions
 	/// <param name="endpoint">The endpoint (location).</param>
 	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
+	/// <param name="httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
@@ -218,7 +218,7 @@ public static class KernelExtensions
 	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
 	/// <param name="optionsCallback">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/> callback.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
+	/// <param name="httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
@@ -241,7 +241,7 @@ public static class KernelExtensions
 	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
 	/// <param name="options">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/>.</param>
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-	/// <param name = "httpClient" > The optional<see cref = "HttpClient" />.</ param >
+	/// <param name="httpClient" > The optional<see cref = "HttpClient" />.</ param >
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
 	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = null)
     {

--- a/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
@@ -179,7 +179,7 @@ public static class KernelExtensions
         CancellationToken cancellationToken = default,
 		HttpClient? httpClient = default)
     {
-        return AddMcpFunctionsFromSseServerAsync(plugins, serverName, new Uri(endpoint), loggerFactory, cancellationToken, httpClient));
+        return AddMcpFunctionsFromSseServerAsync(plugins, serverName, new Uri(endpoint), loggerFactory, cancellationToken, httpClient);
     }
 
 	/// <summary>
@@ -209,7 +209,7 @@ public static class KernelExtensions
             Name = serverName,
             Endpoint = endpoint,
             LoggerFactory = loggerFactory
-        }, cancellationToken, httpClient));
+        }, cancellationToken, httpClient);
     }
 
 	/// <summary>
@@ -224,7 +224,7 @@ public static class KernelExtensions
         this KernelPluginCollection plugins,
         Action<ModelContextProtocolSemanticKernelSseOptions> optionsCallback,
         CancellationToken cancellationToken = default,
-		HttpClient? httpClient = defaul)
+		HttpClient? httpClient = default)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(optionsCallback);
@@ -243,7 +243,7 @@ public static class KernelExtensions
 	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
 	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
 	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = defaul)
+	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = default)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(options);

--- a/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
+++ b/src/ModelContextProtocol-SemanticKernel/Extensions/KernelExtensions.cs
@@ -161,40 +161,44 @@ public static class KernelExtensions
         return StdioMap[key] = stdioKernelPlugin;
     }
 
-    /// <summary>
-    /// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
-    /// </summary>
-    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
-    /// <param name="serverName">The MCP Server name.</param>
-    /// <param name="endpoint">The endpoint (location).</param>
-    /// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
-    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-    public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
+	/// <summary>
+	/// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
+	/// </summary>
+	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+	/// <param name="serverName">The MCP Server name.</param>
+	/// <param name="endpoint">The endpoint (location).</param>
+	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
+	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
+	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
+	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
         string serverName,
         string endpoint,
         ILoggerFactory? loggerFactory = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+		HttpClient? httpClient = default)
     {
-        return AddMcpFunctionsFromSseServerAsync(plugins, serverName, new Uri(endpoint), loggerFactory, cancellationToken);
+        return AddMcpFunctionsFromSseServerAsync(plugins, serverName, new Uri(endpoint), loggerFactory, cancellationToken, httpClient));
     }
 
-    /// <summary>
-    /// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
-    /// </summary>
-    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
-    /// <param name="serverName">The MCP Server name.</param>
-    /// <param name="endpoint">The endpoint (location).</param>
-    /// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
-    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-    public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
+	/// <summary>
+	/// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
+	/// </summary>
+	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+	/// <param name="serverName">The MCP Server name.</param>
+	/// <param name="endpoint">The endpoint (location).</param>
+	/// <param name="loggerFactory">The optional <see cref="ILoggerFactory"/>.</param>
+	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
+	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
+	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
         string serverName,
         Uri endpoint,
         ILoggerFactory? loggerFactory = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+		HttpClient? httpClient = default)
     {
         Guard.NotNull(plugins);
         Guard.NotNullOrWhiteSpace(serverName);
@@ -205,20 +209,22 @@ public static class KernelExtensions
             Name = serverName,
             Endpoint = endpoint,
             LoggerFactory = loggerFactory
-        }, cancellationToken);
+        }, cancellationToken, httpClient));
     }
 
-    /// <summary>
-    /// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
-    /// </summary>
-    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
-    /// <param name="optionsCallback">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/> callback.</param>
-    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-    public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
+	/// <summary>
+	/// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
+	/// </summary>
+	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+	/// <param name="optionsCallback">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/> callback.</param>
+	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
+	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
+	public static Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(
         this KernelPluginCollection plugins,
         Action<ModelContextProtocolSemanticKernelSseOptions> optionsCallback,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+		HttpClient? httpClient = defaul)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(optionsCallback);
@@ -226,17 +232,18 @@ public static class KernelExtensions
         var options = new ModelContextProtocolSemanticKernelSseOptions();
         optionsCallback(options);
 
-        return AddMcpFunctionsFromSseServerAsync(plugins, options, cancellationToken);
+        return AddMcpFunctionsFromSseServerAsync(plugins, options, cancellationToken, httpClient);
     }
 
-    /// <summary>
-    /// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
-    /// </summary>
-    /// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
-    /// <param name="options">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/>.</param>
-    /// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
-    public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default)
+	/// <summary>
+	/// Creates a Model Content Protocol plugin from an SSE server that contains the specified MCP functions and adds it into the plugin collection.
+	/// </summary>
+	/// <param name="plugins">The plugin collection to which the new plugin should be added.</param>
+	/// <param name="options">The <see cref="ModelContextProtocolSemanticKernelSseOptions"/>.</param>
+	/// <param name="cancellationToken">The optional <see cref="CancellationToken"/>.</param>
+	/// <param name="httpClient">The <see cref="HttpClient"/>.</param>
+	/// <returns>A <see cref="KernelPlugin"/> containing the functions.</returns>
+	public static async Task<KernelPlugin> AddMcpFunctionsFromSseServerAsync(this KernelPluginCollection plugins, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken = default, HttpClient? httpClient = defaul)
     {
         Guard.NotNull(plugins);
         Guard.NotNull(options);
@@ -260,7 +267,7 @@ public static class KernelExtensions
             return sseKernelPlugin;
         }
 
-        var mcpClient = await GetSseClientAsync(serverName, options, cancellationToken).ConfigureAwait(false);
+        var mcpClient = await GetSseClientAsync(serverName, options, httpClient, cancellationToken).ConfigureAwait(false);
         var functions = await mcpClient.MapToFunctionsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
         cancellationToken.Register(() => mcpClient.DisposeAsync().ConfigureAwait(false).GetAwaiter().GetResult());
@@ -294,7 +301,7 @@ public static class KernelExtensions
         return await McpClientFactory.CreateAsync(clientTransport, clientOptions, loggerFactory: loggerFactory, cancellationToken: cancellationToken);
     }
 
-    private static async Task<IMcpClient> GetSseClientAsync(string serverName, ModelContextProtocolSemanticKernelSseOptions options, CancellationToken cancellationToken)
+    private static async Task<IMcpClient> GetSseClientAsync(string serverName, ModelContextProtocolSemanticKernelSseOptions options, HttpClient? httpClient, CancellationToken cancellationToken)
     {
         var clientOptions = GetMcpClientOptions(serverName, "sse");
 
@@ -306,9 +313,17 @@ public static class KernelExtensions
             AdditionalHeaders = options.AdditionalHeaders,
             Name = clientOptions.ClientInfo?.Name
         };
-        var clientTransport = new SseClientTransport(sseOptions, loggerFactory);
+		SseClientTransport clientTransport;
+		if (httpClient is null)
+		{
+			clientTransport = new SseClientTransport(sseOptions, loggerFactory);
+		}
+		else
+		{
+			clientTransport = new SseClientTransport(sseOptions, httpClient, loggerFactory);
+		}
 
-        return await McpClientFactory.CreateAsync(clientTransport, clientOptions, loggerFactory: loggerFactory, cancellationToken: cancellationToken);
+		return await McpClientFactory.CreateAsync(clientTransport, clientOptions, loggerFactory: loggerFactory, cancellationToken: cancellationToken);
     }
 
     // A plugin name can contain only ASCII letters, digits, and underscores.


### PR DESCRIPTION
This will allows to pass dynamic information such as auth headers or user details to the http request when a mcp tool is invoked.

Currently we need to pass additional information in the header to our Sse tool calls. But we are not able to as it is not possible to provide our own HttpClient and therfore not a delegate. Also the HttpClient is created in the SseClientTransport which has no notion of DI so we are not able to inject a delegate/handler via the http factory (this is by design).

So this PR is to expose more option when registering MCP tools by being able to provide more optional values like the HttpClient